### PR TITLE
spacing between button & textarea -> send_message modal

### DIFF
--- a/app/views/chat/index.pug
+++ b/app/views/chat/index.pug
@@ -34,6 +34,7 @@ block content
                               .controls
                                 textarea.flat.form-control(type='text', name='body', placeholder='Enter your Message here', maxlength='200')
                                 input(type="hidden", name='receiver', value=user._id)
+                              br
                             .form-actions
                               button.btn(type='submit') Send Message
   include ../components/pagination 


### PR DESCRIPTION
## Description
Add a `br` tag in between Textarea & Send Message button

## Issue Addressed (if applicable)
#219 

## Type
<!--- What types of changes does your code introduce? Put an `x` in all options that apply. -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Screenshots (if applicable):
This is how it looks after the fix. Issue screenshot is available in the #219  issue.

![screen shot 2018-08-13 at 12 01 49 am](https://user-images.githubusercontent.com/4654382/44005149-234a84bc-9e8c-11e8-98ae-0765e338698c.jpg)


<!-- ### How Has This Been Tested?
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed. -->
I have tested it manually, in Chome & Firefox browsers
