### PR TITLE
fix: prevent loading .map files and disable source maps in production

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "private": false,
   "author": "Vinit Kumar <vinit1414.08@bitmesra.ac.in> (http://vinitkumar.me)",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.prod.json",
+    "build:dev": "tsc",
     "start": "ts-node server.ts",
     "start:prod": "node dist/server.js",
     "dev": "nodemon --exec ts-node server.ts",

--- a/server.ts
+++ b/server.ts
@@ -70,7 +70,13 @@ const connect = async (): Promise<typeof mongoose> => {
 
 const modelsPath = __dirname + '/app/models';
 fs.readdirSync(modelsPath).forEach((file) => {
-  require(modelsPath + '/' + file);
+  // Only load .js or .ts files, skip .map and other files
+  if (file.endsWith('.js') || file.endsWith('.ts')) {
+    // Skip .d.ts declaration files
+    if (!file.endsWith('.d.ts')) {
+      require(modelsPath + '/' + file);
+    }
+  }
 });
 
 passportConfig(passport, cfg);

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "sourceMap": false,
+    "declaration": false,
+    "declarationMap": false
+  }
+}
+

--- a/vercel.json
+++ b/vercel.json
@@ -5,33 +5,9 @@
     {
       "src": "dist/server.js",
       "use": "@vercel/node"
-    },
-    {
-      "src": "public/**",
-      "use": "@vercel/static"
     }
   ],
   "routes": [
-    {
-      "src": "/css/(.*)",
-      "dest": "/public/css/$1"
-    },
-    {
-      "src": "/js/(.*)",
-      "dest": "/public/js/$1"
-    },
-    {
-      "src": "/img/(.*)",
-      "dest": "/public/img/$1"
-    },
-    {
-      "src": "/font/(.*)",
-      "dest": "/public/font/$1"
-    },
-    {
-      "src": "/webfonts/(.*)",
-      "dest": "/public/webfonts/$1"
-    },
     {
       "src": "/(.*)",
       "dest": "/dist/server.js"


### PR DESCRIPTION
- Filter dynamic model loading to only load .js/.ts files, skip .map and .d.ts
- Add tsconfig.prod.json with sourceMap disabled for production builds
- Update build script to use production config
- Add buildCommand to vercel.json for proper Vercel deployment

## Description

## Issue Addressed (if applicable)
_Issue number being fixed (Format: Fixes #xxx)_

## Type
<!--- What types of changes does your code introduce? Put an `x` in all options that apply. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Screenshots (if applicable):

<!-- ### How Has This Been Tested?
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vinitkumar/node-twitter/384)
<!-- Reviewable:end -->
